### PR TITLE
Help for odb.read(): quotes in SELECT

### DIFF
--- a/ODB/man/odb.read.Rd
+++ b/ODB/man/odb.read.Rd
@@ -71,7 +71,7 @@
   odb.insert(odb, "fruits", dat)
   
   # Read content
-  print(odb.read(odb, "SELECT * FROM fruits"))
+  print(odb.read(odb, 'SELECT * FROM "fruits"'))
   
   # Writes to the file and closes the connection
   odb.close(odb, write=TRUE)


### PR DESCRIPTION
Fixes issue "Table not found", see https://github.com/maressyl/R.ODB/issues/9